### PR TITLE
671 equality info changes sfr

### DIFF
--- a/app/data/ShortFormatPreSentenceReportData.java
+++ b/app/data/ShortFormatPreSentenceReportData.java
@@ -215,6 +215,11 @@ public class ShortFormatPreSentenceReportData extends ReportGeneratorWizardData 
     @JsonProperty("_PROPOSAL_")
     private String proposal;
 
+    @RequiredOnPage(value = 8, message = "Confirm that you have considered equality and diversity information")
+    @JsonProperty("CONFIRM_EIF")
+    private String confirmEIF;
+
+
     // Page 9
 
     @OnPage(9)
@@ -256,6 +261,10 @@ public class ShortFormatPreSentenceReportData extends ReportGeneratorWizardData 
     @OnPage(9)
     @JsonProperty("DOMESTIC_ABUSE_INFORMATION_SOURCE")
     private boolean domesticAbuseInformationSource;
+
+    @OnPage(9)
+    @JsonProperty("EQUALITY_INFORMATION_FORM_INFORMATION_SOURCE")
+    private boolean equalityInformationFormInformationSource;
 
     @OnPage(9)
     @JsonProperty("OTHER_INFORMATION_SOURCE")

--- a/app/views/shortFormatPreSentenceReport/hiddenInputs/page8Fields.scala.html
+++ b/app/views/shortFormatPreSentenceReport/hiddenInputs/page8Fields.scala.html
@@ -3,3 +3,5 @@
 @(reportForm: Form[_])
 
 @inputHidden(reportForm("proposal"))
+@inputHidden(reportForm("confirmEIF"))
+

--- a/app/views/shortFormatPreSentenceReport/hiddenInputs/page9Fields.scala.html
+++ b/app/views/shortFormatPreSentenceReport/hiddenInputs/page9Fields.scala.html
@@ -12,5 +12,6 @@
 @inputHidden(reportForm("policeInformationSource"))
 @inputHidden(reportForm("sentencingGuidelinesInformationSource"))
 @inputHidden(reportForm("domesticAbuseInformationSource"))
+@inputHidden(reportForm("equalityInformationFormInformationSource"))
 @inputHidden(reportForm("otherInformationSource"))
 @inputHidden(reportForm("otherInformationDetails"))

--- a/app/views/shortFormatPreSentenceReport/page8.scala.html
+++ b/app/views/shortFormatPreSentenceReport/page8.scala.html
@@ -35,7 +35,7 @@
     <div class="govuk-form-group">
     <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-label">I confirm that equalities and diversity information has been considered as part of preparing the report and proposal</legend>
-        <div class="govuk-checkboxes" data-module="progressive-radios">
+        <div class="govuk-radios" data-module="progressive-radios">
             @inputRadioGroup(reportForm("confirmEIF"), options = Seq("yes"->"Yes","no"->"No"))
         </div>
     </fieldset>

--- a/app/views/shortFormatPreSentenceReport/page8.scala.html
+++ b/app/views/shortFormatPreSentenceReport/page8.scala.html
@@ -12,22 +12,34 @@
 @implicitField = @{ FieldConstructor(govukElements.f) }
 
 @proposalHint = {
-    <p>Have you considered what equality and diversity issues are present and how they can help inform your proposal?</p>
-    <p>Have you used the effective proposal tool?</p>
-    <p>Be aware of the sentencing guidelines and relevant legislation. Remember to reference the sentencing intentions of the court, if they were made clear.</p>
-    <p>Consider all possible sentencing options, and whether or not the offender is past the custody threshold or suitable for a community order.</p>
-    <p>Consider and describe both aggravating or mitigating factors.</p>
-    <p>Consider whether specific needs such as gender, maturity, diversity make particular sentences more appropriate.</p>
-    <p>In cases of women, ensure that you think about women only disposals and that your proposal gives a robust community option.</p>
-    <p>Make clear how your proposals will manage risk.</p>
-    <p>What will the impact of the sentence be on the offender?</p>
-    <p>How will the proposed sentence affect the offender’s family and anyone for whom they have caring responsibilities?</p>
-    <p>Remember that evidence shows that imprisonment of mothers has significant impacts on those that they care for.</p>
-    <p>If relevant, what is not suitable in this case?</p>
-    <p>Are there any relevant alternative requirements that the offender may have been eligible for, but circumstances have made them unsuitable for participation?</p>
-    <p>Remember that your proposal should be commensurate with risk and need. Proposals should not be made for suspended sentence orders.</p>
+    <p>Have you used the Effective Proposal Framework?</p>
+    <p>Be aware of the sentencing guidelines and relevant legislation. Remember to refer to the sentencing intentions of the court, if they were made clear.</p>
+    <p>Be clear how your proposal will manage risk.</p>
+    <p>Consider the impact of the sentence on the offender.</p>
+    <p>Consider how the proposed sentence will affect the offender’s family and anyone for whom they have caring responsibilities. Remember, evidence shows that imprisoning mothers significantly impacts on children in their care.
+    </p>
+    <p>A persuasive proposal for sentence considers the relevance of other options. For example, when deciding between proposals for custody or a high end Community Order, explaining the reasons for the proposal adds to the confidence of sentencers.</p>
+    <p>When proposing a sentence for a high end Community Order, outlining why the proposal is being made - and explaining why a proposal for custody is not being made - makes the report more persuasive.</p>
+    <p>Likewise, when custody is not inevitable, being clear why custody is being proposed, and explaining why a Community Order is not manageable, assures the sentencer that options have been considered.</p>
+    <p>Consider what equality and diversity issues are present and how they can help inform your proposal. Do specific needs such as gender, diversity, maturity make particular sentences more appropriate?
+        For women offenders, ensure that you consider women-specific disposals.</p>
+    <p>Are there any relevant alternative requirements that the offender is eligible for, but circumstances make them unsuitable?</p>
+    <p>Remember, your proposal should be commensurate with risk and need. Proposals should not be made for Suspended Sentence Orders, if an offender is manageable in the community, a Community Order should be proposed.</p>
+
 }
 
+
+
+
 @popup(reportForm, encrypter, "Proposal", 8) {
+    <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-label">I confirm that equalities and diversity information has been considered as part of preparing the report and proposal</legend>
+        <div class="govuk-checkboxes" data-module="progressive-radios">
+            @inputRadioGroup(reportForm("confirmEIF"), options = Seq("yes"->"Yes","no"->"No"))
+        </div>
+    </fieldset>
+    </div>
+
     @textarea(reportForm("proposal"), '_label -> "Enter a proposed sentence", '_hint -> proposalHint, Symbol("data-limit") -> "3000")
 }

--- a/app/views/shortFormatPreSentenceReport/page9.scala.html
+++ b/app/views/shortFormatPreSentenceReport/page9.scala.html
@@ -27,6 +27,7 @@
                 @checkbox(reportForm("policeInformationSource"), '_label -> "Police information")
                 @checkbox(reportForm("sentencingGuidelinesInformationSource"), '_label -> "Sentencing guidelines")
                 @checkbox(reportForm("domesticAbuseInformationSource"), '_label -> "Domestic abuse call out information")
+                @checkbox(reportForm("equalityInformationFormInformationSource"), '_label -> "Equality Information Form (EIF)")
                 @checkbox(reportForm("otherInformationSource"), '_label -> "Other (please specify below)", Symbol("data-aria-controls") -> "other-sources")
 
                 <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden govuk-!-margin-top-2" id="other-sources">

--- a/features/bdd/shortformatpresentencereport/proposal.feature
+++ b/features/bdd/shortformatpresentencereport/proposal.feature
@@ -16,6 +16,12 @@ Feature: Short Format Pre-sentence Report - Proposal
     And they select "What to include" hyperlink
     Then the UI should expand to show additional content to the end user
 
+  Scenario: Delius user confirms that they have considered equality and diversity information
+
+    Given that the user selects "yes" or "no" radio buttons
+    Then they can continue to enter a proposed sentence
+
+
   Scenario: Delius user completes all options on the "Risk assessment" UI
 
     Given they enter the following information

--- a/features/bdd/shortformatpresentencereport/sourcesOfInformation.feature
+++ b/features/bdd/shortformatpresentencereport/sourcesOfInformation.feature
@@ -23,23 +23,25 @@ Feature: Short Format Pre-sentence Report - Sources of information
     And that the "Police information" is ticked
     And that the "Sentencing guidelines" is ticked
     And that the "Domestic abuse call out information" is ticked
+    And that the "Equality Information Form " is ticked
     And that the "Other (please specify below)" is ticked
     When they enter the following information
       | Other source(s) of information | Some other sources of information text |
 
     Then the following information should be saved in the report
-      | interviewInformationSource            | true                                   |
-      | serviceRecordsInformationSource       | true                                   |
-      | cpsSummaryInformationSource           | true                                   |
-      | oasysAssessmentsInformationSource     | true                                   |
-      | previousConvictionsInformationSource  | true                                   |
-      | victimStatementInformationSource      | true                                   |
-      | childrenServicesInformationSource     | true                                   |
-      | policeInformationSource               | true                                   |
-      | sentencingGuidelinesInformationSource | true                                   |
-      | domesticAbuseInformationSource        | true                                   |
-      | otherInformationSource                | true                                   |
-      | otherInformationDetails               | Some other sources of information text |
+      | interviewInformationSource                      | true                                   |
+      | serviceRecordsInformationSource                 | true                                   |
+      | cpsSummaryInformationSource                     | true                                   |
+      | oasysAssessmentsInformationSource               | true                                   |
+      | previousConvictionsInformationSource            | true                                   |
+      | victimStatementInformationSource                | true                                   |
+      | childrenServicesInformationSource               | true                                   |
+      | policeInformationSource                         | true                                   |
+      | sentencingGuidelinesInformationSource           | true                                   |
+      | domesticAbuseInformationSource                  | true                                   |
+      | equalityInformationFormInformationSource        | true                                   |
+      | otherInformationSource                          | true                                   |
+      | otherInformationDetails                         | Some other sources of information text |
 
   Scenario: Delius user wants to continue writing the Short Format Pre-sentence Report
 

--- a/features/bdd/shortformatpresentencereport/sourcesOfInformation.feature
+++ b/features/bdd/shortformatpresentencereport/sourcesOfInformation.feature
@@ -23,7 +23,7 @@ Feature: Short Format Pre-sentence Report - Sources of information
     And that the "Police information" is ticked
     And that the "Sentencing guidelines" is ticked
     And that the "Domestic abuse call out information" is ticked
-    And that the "Equality Information Form " is ticked
+    And that the "Equality Information Form (EIF)" is ticked
     And that the "Other (please specify below)" is ticked
     When they enter the following information
       | Other source(s) of information | Some other sources of information text |

--- a/test/bdd/shortformatpresentencereport/ProposalSteps.java
+++ b/test/bdd/shortformatpresentencereport/ProposalSteps.java
@@ -19,6 +19,8 @@ public class ProposalSteps {
 
     @Given("^Delius User completes the \"Proposal\" UI within the Short Format Pre-sentence Report$")
     public void deliusUserCompletesThePageWithinTheReport() throws Throwable {
+        page.clickRadioButtonWithLabelWithinLegend("Yes", "I confirm that equalities and diversity information has been considered as part of preparing the report and proposal");
+        page.clickRadioButtonWithLabelWithinLegend("No", "I confirm that equalities and diversity information has been considered as part of preparing the report and proposal");
         page.fillTextArea("Enter a proposed sentence", "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum nec sem eget lacus euismod vulputate sit amet sed nulla.");
         page.clickButton("Continue");
     }

--- a/test/controllers/ShortFormatPreSentenceReportControllerTest.java
+++ b/test/controllers/ShortFormatPreSentenceReportControllerTest.java
@@ -1052,6 +1052,7 @@ public class ShortFormatPreSentenceReportControllerTest extends WithApplication 
                 put("previousSupervisionResponse", "Good");
                 put("additionalPreviousSupervision", "Some previous supervision response");
 
+                put("confirmEIF", "true");
                 put("proposal", "Some proposal");
 
                 put("pageNumber", "8");
@@ -1116,6 +1117,7 @@ public class ShortFormatPreSentenceReportControllerTest extends WithApplication 
                 put("previousSupervisionResponse", "Good");
                 put("additionalPreviousSupervision", "Some previous supervision response");
 
+                put("confirmEIF", "true");
                 put("proposal", "Some proposal");
 
                 put("otherInformationSource", "true");
@@ -1181,7 +1183,7 @@ public class ShortFormatPreSentenceReportControllerTest extends WithApplication 
                 put("riskOfSeriousHarm", "Some risk of serious harm");
                 put("previousSupervisionResponse", "Good");
                 put("additionalPreviousSupervision", "Some previous supervision response");
-
+                put("confirmEIF", "true");
                 put("proposal", "Some proposal");
 
                 put("interviewInformationSource", "true");
@@ -1261,6 +1263,7 @@ public class ShortFormatPreSentenceReportControllerTest extends WithApplication 
                 put("riskOfSeriousHarm", "Some risk of serious harm");
                 put("previousSupervisionResponse", "Good");
                 put("additionalPreviousSupervision", "Some previous supervision response");
+                put("confirmEIF", "true");
                 put("proposal", "Some proposal");
 
                 put("interviewInformationSource", "true");
@@ -1342,6 +1345,7 @@ public class ShortFormatPreSentenceReportControllerTest extends WithApplication 
                 put("riskOfSeriousHarm", "Some risk of serious harm");
                 put("previousSupervisionResponse", "Good");
                 put("additionalPreviousSupervision", "Some previous supervision response");
+                put("confirmEIF", "true");
                 put("proposal", "Some proposal");
 
                 put("interviewInformationSource", "true");

--- a/test/controllers/ShortFormatPreSentenceReportControllerTest.java
+++ b/test/controllers/ShortFormatPreSentenceReportControllerTest.java
@@ -1194,6 +1194,7 @@ public class ShortFormatPreSentenceReportControllerTest extends WithApplication 
                 put("policeInformationSource", "true");
                 put("sentencingGuidelinesSource", "true");
                 put("domesticAbuseInformationSource", "true");
+                put("equalityInformationFormInformationSource", "true");
                 put("otherInformationSource", "true");
                 put("otherInformationDetails", "These notes are spelled correctly");
 
@@ -1272,6 +1273,7 @@ public class ShortFormatPreSentenceReportControllerTest extends WithApplication 
                 put("policeInformationSource", "true");
                 put("sentencingGuidelinesSource", "true");
                 put("domesticAbuseInformationSource", "true");
+                put("equalityInformationFormInformationSource", "true");
                 put("otherInformationSource", "true");
                 put("otherInformationDetails", "These notes are spelled correctly");
 
@@ -1352,6 +1354,7 @@ public class ShortFormatPreSentenceReportControllerTest extends WithApplication 
                 put("policeInformationSource", "true");
                 put("sentencingGuidelinesSource", "true");
                 put("domesticAbuseInformationSource", "true");
+                put("equalityInformationFormInformationSource", "true");
                 put("otherInformationSource", "true");
                 put("otherInformationDetails", "These notes are spelled correctly");
 

--- a/test/views/pages/shortformatpresentencereport/ProposalPage.java
+++ b/test/views/pages/shortformatpresentencereport/ProposalPage.java
@@ -22,6 +22,7 @@ public class ProposalPage extends ShortFormatPreSentencePopupReportPage {
     }
 
     public ProposalPage gotoNext() {
+        $(id("confirmEIF_yes")).click();
         fillInputWithId("proposal", "Proposal");
         $(id("nextButton")).click();
         return this;


### PR DESCRIPTION
Changes made:

- Added mandatory radio button to confirm equality and diversity information has been considered. I used a radio button instead of a checkbox as user needs to select 'yes' or 'no' not both so checkbox wouldn't be suitable.                                                                                                                                

- Added check box for 'Equality Information Form (EIF)' that pulls through to PDF. This has been added to pdf-generator so displays in table.

- Updated content in 'What to include' section within 'Enter a proposed sentence'