### PR TITLE
Dt 689 remove custody api

### DIFF
--- a/app/injection/PrisonerApiProvider.java
+++ b/app/injection/PrisonerApiProvider.java
@@ -4,6 +4,7 @@ import com.typesafe.config.Config;
 import interfaces.PrisonerApi;
 import play.inject.Injector;
 import services.NomisCustodyApi;
+import services.NomisElite2Api;
 import services.stubs.StubPrisonerApi;
 
 import javax.inject.Inject;
@@ -23,7 +24,9 @@ public class PrisonerApiProvider implements Provider<PrisonerApi> {
     @Override
     public PrisonerApi get() {
         return "stub".equals(prisonerApiProvider) ?
-                        injector.instanceOf(StubPrisonerApi.class) :
+                injector.instanceOf(StubPrisonerApi.class) :
+                "elite".equals(prisonerApiProvider) ?
+                        injector.instanceOf(NomisElite2Api.class) :
                         injector.instanceOf(NomisCustodyApi.class);
     }
 }

--- a/test/bdd/GlobalHooks.java
+++ b/test/bdd/GlobalHooks.java
@@ -69,7 +69,7 @@ public class GlobalHooks extends WithChromeBrowser {
                 .configure("store.alfresco.url", String.format("http://localhost:%d/", Ports.ALFRESCO.getPort()))
                 .configure("offender.api.url", String.format("http://localhost:%d/", Ports.OFFENDER_API.getPort()))
                 .configure("nomis.api.url", String.format("http://localhost:%d/", Ports.CUSTODY_API.getPort()))
-                .configure("prisoner.api.provider", "custody")
+                .configure("prisoner.api.provider", "elite")
                 .configure("custody.api.auth.username", "username")
                 .configure("custody.api.auth.password", "password")
                 .build();

--- a/test/bdd/wiremock/CustodyApiMock.java
+++ b/test/bdd/wiremock/CustodyApiMock.java
@@ -38,9 +38,9 @@ public class CustodyApiMock {
                                 okForContentType("application/json", loadResource("/nomsoffender/token.json"))));
 
         custodyApiWireMock.stubFor(
-                get(urlMatching("/custodyapi/api/offenders/nomsId/.*"))
+                get(urlMatching("/elite2api/api/offenders/.*"))
                         .willReturn(
-                                okForContentType("application/json", loadResource("/nomsoffender/offender_G8020GG.json"))));
+                                okForContentType("application/json", loadResource("/nomselite2offender/offender_G8020GG.json"))));
 
         custodyApiWireMock.stubFor(
                 get(urlMatching("/elite2api/api/bookings/offenderNo/.*"))
@@ -48,12 +48,7 @@ public class CustodyApiMock {
                                 okForContentType("application/json", loadResource("/nomselite2offender/offender_G8020GG.json"))));
 
         custodyApiWireMock.stubFor(
-                get(urlMatching("/custodyapi/api/offenders/nomsId/.*/images"))
-                        .willReturn(
-                                okForContentType("application/json", loadResource("/nomsoffender/images_123.json"))));
-
-        custodyApiWireMock.stubFor(
-                get(urlMatching("/custodyapi/api/offenders/nomsId/.*/images/.*/thumbnail"))
+                get(urlMatching("/elite2api/api/bookings/offenderNo/.*/image/data"))
                         .willReturn(
                                 ok().withHeader(CONTENT_TYPE, "image/jpeg").withBody(loadResourceBytes("/nomsoffender/image_3.jpeg"))));
 
@@ -65,13 +60,13 @@ public class CustodyApiMock {
     }
 
     public CustodyApiMock stubOffenderWithName(String fullName) {
-        val offender = JsonHelper.jsonToObjectMap(loadResource("/nomsoffender/offender_G8020GG.json"));
+        val offender = JsonHelper.jsonToObjectMap(loadResource("/nomselite2offender/offender_G8020GG.json"));
         val firstName = fullName.split(" ")[0];
         val surname = fullName.split(" ")[1];
         offender.put("firstName", firstName);
-        offender.put("surname", surname);
+        offender.put("lastName", surname);
         custodyApiWireMock.stubFor(
-                get(urlMatching("/custodyapi/api/offenders/nomsId/.*"))
+                get(urlMatching("/elite2api/api/offenders/.*"))
                         .willReturn(ok().withBody(JsonHelper.stringify(offender))));
 
         return this;
@@ -79,7 +74,7 @@ public class CustodyApiMock {
 
     public CustodyApiMock stubOffenderNotFound() {
         custodyApiWireMock.stubFor(
-                get(urlMatching("/custodyapi/api/offenders/nomsId/.*"))
+                get(urlMatching("/elite2api/api/offenders/.*"))
                         .willReturn(notFound()));
 
         return this;
@@ -87,7 +82,7 @@ public class CustodyApiMock {
 
     public CustodyApiMock stubOffenderUnavailable() {
         custodyApiWireMock.stubFor(
-                get(urlMatching("/custodyapi/api/offenders/nomsId/.*"))
+                get(urlMatching("/elite2api/api/offenders/.*"))
                         .willReturn(serviceUnavailable()));
 
         return this;

--- a/test/resources/nomselite2offender/offender_G8020GG.json
+++ b/test/resources/nomselite2offender/offender_G8020GG.json
@@ -162,7 +162,7 @@
     "agencyId": "ZZGHI",
     "locationId": 6601,
     "description": "RECP",
-    "agencyName": "Ghost Holding Establishment"
+    "agencyName": "HMP Humber"
   },
   "facialImageId": 1373,
   "dateOfBirth": "1973-08-12",

--- a/test/resources/nomselite2offender/offender_G8020GG_no_category.json
+++ b/test/resources/nomselite2offender/offender_G8020GG_no_category.json
@@ -162,7 +162,7 @@
     "agencyId": "ZZGHI",
     "locationId": 6601,
     "description": "RECP",
-    "agencyName": "Ghost Holding Establishment"
+    "agencyName": "HMP Humber"
   },
   "facialImageId": 1373,
   "dateOfBirth": "1973-08-12",

--- a/test/services/NomisElite2ApiIntegrationTest.java
+++ b/test/services/NomisElite2ApiIntegrationTest.java
@@ -262,7 +262,7 @@ public class NomisElite2ApiIntegrationTest extends WithApplication {
     public void willGetPrisonLocationFromPrisonerDetails() {
         val maybeOffender = prisonerApi.getOffenderByNomsNumber("G8020GG").toCompletableFuture().join();
 
-        assertThat(maybeOffender.orElseThrow(RuntimeException::new).getInstitution().getDescription()).isEqualTo("Ghost Holding Establishment");
+        assertThat(maybeOffender.orElseThrow(RuntimeException::new).getInstitution().getDescription()).isEqualTo("HMP Humber");
     }
 
     @Test

--- a/test/services/NomisElite2Api_OffenderTransformerTest.java
+++ b/test/services/NomisElite2Api_OffenderTransformerTest.java
@@ -1,0 +1,68 @@
+package services;
+
+import lombok.val;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static services.NomisElite2Api.LivingUnit;
+import static services.NomisElite2Api.OffenderEntity;
+import static services.NomisElite2Api.OffenderTransformer.offenderOf;
+
+public class NomisElite2Api_OffenderTransformerTest {
+    @Test
+    public void detailsCopied() {
+
+        val offenderEntity =
+                OffenderEntity.builder()
+                        .firstName("Bob")
+                        .lastName("Builder")
+                        .bookingNo("V38608")
+                        .assignedLivingUnit(LivingUnit
+                                .builder()
+                                .agencyName("HMP Brixton")
+                                .build())
+                        .build();
+
+        val offender = offenderOf(offenderEntity);
+
+        assertThat(offender.getFirstName()).isEqualTo("Bob");
+        assertThat(offender.getSurname()).isEqualTo("Builder");
+        assertThat(offender.getMostRecentPrisonerNumber()).isEqualTo("V38608");
+    }
+
+    @Test
+    public void locationTakenFromAssignedLivingUnitAgencyName() {
+
+        val offenderEntity =
+                OffenderEntity.builder()
+                        .firstName("Bob")
+                        .lastName("Builder")
+                        .bookingNo("V38608")
+                        .assignedLivingUnit(LivingUnit
+                                .builder()
+                                .agencyName("HMP Brixton")
+                                .build())
+                        .build();
+
+        val offender = offenderOf(offenderEntity);
+
+        assertThat(offender.getInstitution().getDescription()).isEqualTo("HMP Brixton");
+    }
+
+    @Test
+    public void locationWillBeUnknownWhenAssignedLivingUnitMissing() {
+
+        val offenderEntity =
+                OffenderEntity.builder()
+                        .firstName("Bob")
+                        .lastName("Builder")
+                        .bookingNo("V38608")
+                        .assignedLivingUnit(null)
+                        .build();
+
+        val offender = offenderOf(offenderEntity);
+
+        assertThat(offender.getInstitution().getDescription()).isEqualTo("Unknown");
+    }
+
+}


### PR DESCRIPTION
This is first of 3 PRs with aim to me Newtech to elite-api from custody-api
1) This PR adds the elite api calls and wiring, and moving BDDs to use elite by default
2) Next will use feature switch once deployed to use elite-api rather than custody-api
3) Final PR will remove all references to custody-api