### PR TITLE
PIC-1132 Offender Assessment erroneous Interview option

### DIFF
--- a/app/views/oralReport/page6.scala.html
+++ b/app/views/oralReport/page6.scala.html
@@ -58,8 +58,6 @@
         <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-label">Select any factors relating to offending behaviour and the individual’s need, including any protective factors.</legend>
             <div class="govuk-checkboxes" data-module="checkboxes">
-                @checkbox(reportForm("interviewInformationSource"), '_label -> "Interview")
-
                 @checkbox(reportForm("issueAccommodation"), '_label -> "Accommodation")
                 @checkbox(reportForm("issueEmployment"), '_label -> "Employment, training and education")
                 @checkbox(reportForm("issueFinance"), '_label -> "Finance")


### PR DESCRIPTION
Removed interview checkbox option

Signed-off-by: theDustRoom <paul.massey@digital.justice.gov.uk>