### PR TITLE
Updated PROBATION_OFFENDER_SEARCH_URL in Stage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,7 +350,7 @@ workflows:
           context: hmpps-delius-deploy-to-ecs-stage
           env-vars: >-
             container=new-tech,name=HMPPS_AUTH_BASE_URL,            value=https://sign-in-preprod.hmpps.service.justice.gov.uk/,
-            container=new-tech,name=PROBATION_OFFENDER_SEARCH_URL,  value=https://probation-offender-search-preprod.hmpps.service.justice.gov.uk/,
+            container=new-tech,name=PROBATION_OFFENDER_SEARCH_URL,  value=https://probation-offender-search-staging.hmpps.service.justice.gov.uk/,
             container=new-tech,name=NOMIS_API_BASE_URL,             value=https://api-preprod.prison.service.justice.gov.uk/
           requires:
             - request-pre-prod-approval


### PR DESCRIPTION
Pre-Prod URLs are still used for HMPPS Auth and the NOMIS API.

Relevant Slack thread: https://mojdt.slack.com/archives/CNXK9893K/p1619101055182900