### PR TITLE
Correct text formatting issue in PDF

### DIFF
--- a/app/assets/javascripts/app/helpers/formDataHelper.js
+++ b/app/assets/javascripts/app/helpers/formDataHelper.js
@@ -4,10 +4,17 @@ const updateFormData = ($formData) => {
   }
   const RICH_TEXT = '<!-- RICH_TEXT -->'
   $formData.forEach(($item, $key) => {
-    let textSample = $item.substr(0, 30);
+    let textSample = $item.substr(0, 50);
 
+    // Correct an edge case where this is wrapped in a paragraph
     if (textSample.indexOf(`<p>${ RICH_TEXT }</p>`) !== -1) {
-      $item = $item.replace(`<p>${ RICH_TEXT }</p>`, '') // Correct an edge case where this is wrapped in a paragraph
+      $item = $item.replace(`<p>${ RICH_TEXT }</p>`, '')
+      textSample = $item.substr(0, 30);
+    }
+
+    // Correct a further edge case where this is bold and wrapped in a paragraph
+    if (textSample.indexOf(`<p><strong>${ RICH_TEXT }</strong></p>`) !== -1) {
+      $item = $item.replace(`<p><strong>${ RICH_TEXT }</strong></p>`, '')
       textSample = $item.substr(0, 30);
     }
 


### PR DESCRIPTION
A further edge case formatting issue has been found where a text is copied from Word with a space at the start of the text and this is set as bold. This causes `<p><strong><!-- RICH_TEXT --></strong></p>` to be included at the beginning of the text so the PDF generator does not treat this correctly.

This removes this, as per the previous edge case correction. Not very elegant but...

🐛 Correct edge case formatting issue

Signed-off-by: theDustRoom <paul.massey@digital.justice.gov.uk>