### PR TITLE
PI-3991 Add tinymce to audit-ci allowlist

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,5 +1,8 @@
 {
     "moderate": true,
     "package-manager": "auto",
-    "registry": "https://registry.npmjs.org"
+    "registry": "https://registry.npmjs.org",
+    "allowlist": [
+        "tinymce"
+    ]
 }


### PR DESCRIPTION
We cannot upgrade due to licencing changes, and ndelius-new-tech is being replaced by PSR, so it's not worth finding a replacement for tinymce at this time. It's only used on the client-side, in a controlled environment, so vulnerability impact is minimal.